### PR TITLE
Make dialog content scrollable to prevent hidden overflow on mobile

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -72,15 +72,15 @@ const DialogContent = <T extends ValidComponent = "div">(
       <DialogOverlay />
       <DialogPrimitive.Content
         class={cn(
-          `bg-background data-[expanded]:animate-in
-          data-[closed]:animate-out data-[closed]:fade-out-0
-          data-[expanded]:fade-in-0 data-[closed]:zoom-out-95
-          data-[expanded]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid
-          w-full max-w-[calc(100%-2rem)] -translate-x-1/2
-          -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg
-          duration-200 sm:max-w-lg`,
-          props.class,
-        )}
+  `bg-background data-[expanded]:animate-in
+  data-[closed]:animate-out data-[closed]:fade-out-0
+  data-[expanded]:fade-in-0 data-[closed]:zoom-out-95
+  data-[expanded]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid
+  w-full max-w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)]
+  -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border
+  p-6 shadow-lg overflow-y-auto duration-200 sm:max-w-lg`,
+  props.class,
+)}
         {...rest}
       >
         {props.children}


### PR DESCRIPTION
Make dialog content scrollable on mobile to prevent content overflow from being hidden